### PR TITLE
Fix link to polkadotjs docs

### DIFF
--- a/content/md/en/docs/reference/command-line-tools/polkadot-apps.md
+++ b/content/md/en/docs/reference/command-line-tools/polkadot-apps.md
@@ -5,7 +5,7 @@ keywords:
 ---
 
 The Polkadot-JS Apps is a flexible UI for interacting with a Polkadot or Substrate based node.
-Go to [documentation](https://polkadot.js.org/apps).
+Go to [documentation](https://polkadot.js.org/docs).
 
 This is pre-built [user-facing application](https://github.com/polkadot-js/apps), allowing access to all features available on Substrate chains.
 


### PR DESCRIPTION
The page currently links to https://polkadot.js.org/apps instead of https://polkadot.js.org/docs
This PR fixes this link